### PR TITLE
Use formattedNumber to format zero

### DIFF
--- a/accounting.go
+++ b/accounting.go
@@ -94,15 +94,12 @@ func (accounting *Accounting) init() {
 func (accounting *Accounting) formatMoneyString(formattedNumber string) string {
 	var format string
 
-	zero := "0"
-	if accounting.Precision > 0 {
-		zero += "." + strings.Repeat("0", accounting.Precision)
-	}
+	formattedZero := FormatNumber(0, accounting.Precision, accounting.Thousand, accounting.Decimal)
 
 	if formattedNumber[0] == '-' {
 		format = accounting.FormatNegative
 		formattedNumber = formattedNumber[1:]
-	} else if formattedNumber == zero {
+	} else if formattedNumber == formattedZero {
 		format = accounting.FormatZero
 	} else {
 		format = accounting.Format

--- a/accounting_test.go
+++ b/accounting_test.go
@@ -63,7 +63,7 @@ func TestFormatMoney(t *testing.T) {
 	AssertEqual(t, accounting.FormatMoney(decimal.New(499999, -2)), "$4,999.99")
 	AssertEqual(t, accounting.FormatMoney(decimal.New(500000, 0)), "$500,000.00")
 
-	accounting = NewAccounting( "$", 0, ",", ".","%s %v","-%s %v","%s %v")
+	accounting = NewAccounting("$", 0, ",", ".", "%s %v", "-%s %v", "%s %v")
 	AssertEqual(t, accounting.FormatMoney(123456789.213123), "$ 123,456,789")
 	AssertEqual(t, accounting.FormatMoney(12345678), "$ 12,345,678")
 	AssertEqual(t, accounting.FormatMoney(-12345678), "-$ 12,345,678")
@@ -86,6 +86,10 @@ func TestFormatMoney(t *testing.T) {
 	AssertEqual(t, accounting2.FormatMoney(1000000), "GBP 1,000,000.00")
 	AssertEqual(t, accounting2.FormatMoney(-5000), "GBP (5,000.00)")
 	AssertEqual(t, accounting2.FormatMoney(0), "GBP --")
+
+	accounting2 = Accounting{Symbol: "€", Precision: 2,
+		Decimal: ",", FormatZero: "0.-"}
+	AssertEqual(t, accounting2.FormatMoney(0), "0.-")
 }
 
 func TestFormatMoneyInt(t *testing.T) {


### PR DESCRIPTION
If precision is a `,` then the old code would compare 
`0.00` with `0,00` and FormatZero wouldn't be used.

So format the value `0` with FormatNumber and it will work :)